### PR TITLE
Roofer app tracing

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,3 +53,19 @@ You can list all available presets:
 cd roofer-dev
 cmake --list-presets
 ```
+
+## Logging
+
+There are two logging backends available, the internal and `spdlog`.
+Roofer defaults to the internal logger, which logs to the console.
+With `spdlog`, roofer logs to the console and to a JSON log file.
+To use `spdlog`, set the `RF_USE_LOGGER_SPDLOG` CMake variable `ON`.
+
+The logging verbosity is controlled with the `-v, --verbose` and `-t, --trace` options.
+
+### Tracing
+The `roofer` app can trace object counts and the amount of heap allocation during its process.
+To enable tracing, pass the `--trace` option to `roofer`.
+It is strongly recommended to use `spdlog` if you enable tracing, so that the logs are stored as JSON in the `roofer.log.json` logfile.
+The `tools/plot_traces.py` python script can help you to plot the tracing information.
+The script requires the `matplotlib` and `pandas` libraries to run, it takes the log file as its single argument and writes the plot to `roofer_trace_plot.png`.

--- a/apps/roofer-app/roofer-app.cpp
+++ b/apps/roofer-app/roofer-app.cpp
@@ -167,19 +167,23 @@ void print_help(std::string program_name) {
   std::cout << "   " << program_name;
   std::cout << " -c <file>" << "\n";
   std::cout << "Options:" << "\n";
-  // std::cout << "   -v, --version                Print version information\n";
-  std::cout << "   -h, --help                   Show this help message" << "\n";
-  std::cout << "   -V, --version                Show version" << "\n";
-  std::cout << "   -v, --verbose                Be more verbose" << "\n";
-  std::cout << "   -c <file>, --config <file>   Config file" << "\n";
+  std::cout << "   -h, --help                   Show this help message."
+            << "\n";
+  std::cout << "   -V, --version                Show version." << "\n";
+  std::cout << "   -v, --verbose                Be more verbose." << "\n";
+  std::cout << "   -t, --trace                  Trace the progress. Implies "
+               "--verbose."
+            << "\n";
+  std::cout << "   -c <file>, --config <file>   Config file." << "\n";
   std::cout << "   -r, --rasters                Output rasterised building "
-               "pointclouds"
+               "pointclouds."
             << "\n";
-  std::cout << "   -m, --metadata               Output metadata.json file"
+  std::cout << "   -m, --metadata               Output metadata.json file."
             << "\n";
-  std::cout << "   -i, --index                  Output index.gpkg file" << "\n";
+  std::cout << "   -i, --index                  Output index.gpkg file."
+            << "\n";
   std::cout << "   -a, --all                    Output files for each "
-               "candidate point cloud instead of only the optimal candidate"
+               "candidate point cloud instead of only the optimal candidate."
             << "\n";
 }
 
@@ -415,6 +419,10 @@ int main(int argc, const char* argv[]) {
     logger.set_level(roofer::logger::LogLevel::debug);
   } else {
     logger.set_level(roofer::logger::LogLevel::warning);
+  }
+  // Enabling tracing overwrites the log level
+  if (cmdl[{"-t", "--trace"}]) {
+    logger.set_level(roofer::logger::LogLevel::trace);
   }
 
   // Read configuration

--- a/include/roofer/logger/logger.h
+++ b/include/roofer/logger/logger.h
@@ -72,7 +72,7 @@ namespace roofer::logger {
      * @param name Name of the process, eg. "reconstruct".
      * @param count Current count, eg. the number of reconstructed buildings.
      */
-    void trace(std::string_view name, unsigned int count) {
+    void trace(std::string_view name, size_t count) {
       log(LogLevel::trace,
           fmt::format(R"({{\"name\":\"{}\",\"count\":{}}})", name, count));
     }

--- a/tools/plot_traces.py
+++ b/tools/plot_traces.py
@@ -1,0 +1,54 @@
+import argparse
+import json
+from pathlib import Path
+
+import pandas as pd
+from matplotlib import pyplot as plt
+
+parser = argparse.ArgumentParser(
+    prog='PlotTraces',
+    description='Plot the tracing information of roofer')
+parser.add_argument('logfile')
+
+if __name__ == "__main__":
+    args = parser.parse_args()
+    path_log = Path(args.logfile).absolute()
+
+    with path_log.open() as fo:
+        log_json = json.load(fo)
+
+
+    # Parse the trace messages for easy plotting
+    def parse_trace_message(log):
+        for record in log:
+            if record["level"] == "trace":
+                if record["message"][0] == "{":
+                    m = json.loads(record["message"])
+                    del record["message"]
+                    del record["name"]
+                    del record["level"]
+                    record["time"] = pd.to_datetime(record["time"])
+                    record.update(m)
+                    yield record
+
+
+    trace_df = pd.DataFrame.from_records(parse_trace_message(log_json["log"]))
+    start_time = trace_df.iloc[0]["time"]
+    end_time = trace_df["time"].max()
+    trace_df.loc[:, "duration"] = trace_df["time"].apply(lambda t: (t - start_time).total_seconds())
+
+    fig, (ax_counts, ax_heap) = plt.subplots(2, 1, layout='constrained')
+    # The expected groups are "crop", "reconstruct", "serialize", "heap"
+    for name, group_df in trace_df.groupby("name"):
+        if name != "heap":
+            ax_counts.plot(group_df["duration"], group_df["count"], label=name)
+        else:
+            ax_heap.plot(group_df["duration"], group_df["count"], label=name)
+
+    ax_counts.set_ylabel("Nr. objects produced")
+    ax_counts.legend()
+    ax_counts.set_title(f"Total duration {(end_time - start_time).total_seconds():.2f}s")
+    ax_heap.set_xlabel(f"Duration of the complete program [s]")
+    ax_heap.set_ylabel('Heap allocation [b]')
+    plt.savefig(f"roofer_trace_plot.png")
+    plt.close()


### PR DESCRIPTION
- Adds tracing to the roofer app (with the `-t, --trace` CLI option)
- Tracing info is emitted after a tile is finished. Thus, the level of granularity of the counts depends on the tile size. This has the least overhead i think, and is probably good enough.
- Counts the processed objects and the heap allocations.
- I added a python script to plot the traces. I know rerun is more fancy, but this was quick and easy. The plot looks like this below (this is wipploder, just one tile).
- Added a bit of info on logging to the README

![image](https://github.com/3DBAG/geoflow-roofer/assets/7190603/56cf3cb9-8980-4759-837d-7b915c379af9)
