### PR TITLE
Multihreading and parallel reconstruction in roofer app

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ option(BUILD_SHARED_LIBS "Build using shared libraries (may not work)" OFF)
 option(RF_BUILD_TESTING "Enable tests for roofer" OFF)
 
 # Enable the vcpkg features that are required by the options
-if (RF_USE_LOGGER_SPDLOG)
+if(RF_USE_LOGGER_SPDLOG)
   list(APPEND VCPKG_MANIFEST_FEATURES "spdlog")
 endif()
 if(RF_BUILD_TESTING)
@@ -29,9 +29,9 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 # Don't use extensions, because they might affect compiler compatibility
 set(CMAKE_CXX_EXTENSIONS OFF)
 # Enable position independent code for shared libraries in case we build them
-if (BUILD_SHARED_LIBS OR RF_BUILD_BINDINGS)
+if(BUILD_SHARED_LIBS OR RF_BUILD_BINDINGS)
   set(CMAKE_POSITION_INDEPENDENT_CODE ON)
-endif ()
+endif()
 # CMAKE MODULES
 
 # CMake modules, like the documentation module, go in here
@@ -47,7 +47,9 @@ find_package(
 find_package(nlohmann_json REQUIRED)
 find_package(GEOS CONFIG REQUIRED)
 find_package(laslib CONFIG REQUIRED)
-find_package(libfork CONFIG REQUIRED)
+add_library(BS_thread_pool INTERFACE)
+target_include_directories(BS_thread_pool
+                           INTERFACE ${BS_thread_pool_SOURCE_DIR}/include)
 
 # GDAL
 find_package(GDAL CONFIG REQUIRED)
@@ -103,7 +105,7 @@ endif()
 
 # Python binding
 if(RF_BUILD_BINDINGS)
-    add_subdirectory(rooferpy)
+  add_subdirectory(rooferpy)
 endif()
 
 # EXECUTABLES

--- a/apps/roofer-app/CMakeLists.txt
+++ b/apps/roofer-app/CMakeLists.txt
@@ -5,6 +5,17 @@ set_target_properties("roofer" PROPERTIES CXX_STANDARD 20)
 target_link_libraries("roofer" PRIVATE roofer-extra cmake_git_version_tracking
                                        fmt::fmt BS_thread_pool)
 
+# Used for getting the process memory usage
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+  target_compile_definitions("roofer" PUBLIC "IS_LINUX")
+endif()
+if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+  target_compile_definitions("roofer" PUBLIC "IS_MACOS")
+endif()
+if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
+  target_compile_definitions("roofer" PUBLIC "IS_WINDOWS")
+endif()
+
 install(
   TARGETS "roofer"
   ARCHIVE DESTINATION lib

--- a/apps/roofer-app/CMakeLists.txt
+++ b/apps/roofer-app/CMakeLists.txt
@@ -3,7 +3,7 @@ set(APP_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/roofer-app.cpp")
 add_executable("roofer" ${APP_SOURCES})
 set_target_properties("roofer" PROPERTIES CXX_STANDARD 20)
 target_link_libraries("roofer" PRIVATE roofer-extra cmake_git_version_tracking
-                                       fmt::fmt libfork::libfork)
+                                       fmt::fmt BS_thread_pool)
 
 install(
   TARGETS "roofer"

--- a/apps/roofer-app/crop_tile.hpp
+++ b/apps/roofer-app/crop_tile.hpp
@@ -129,9 +129,17 @@ void crop_tile(const roofer::TBox<double>& tile,
       if (low_lod) {
         ipc.nodata_radii[i] = 0;
       } else {
-        roofer::misc::compute_nodata_circle(ipc.building_clouds[i],
-                                            footprints[i], &ipc.nodata_radii[i],
-                                            &nodata_c);
+        try {
+          roofer::misc::compute_nodata_circle(ipc.building_clouds[i],
+                                              footprints[i],
+                                              &ipc.nodata_radii[i], &nodata_c);
+        } catch (...) {
+          logger.error(
+              "Failed to compute_nodata_circle in crop_tile for {}, setting "
+              "ipc.nodata_radii[i] = 0",
+              ipc.path);
+          ipc.nodata_radii[i] = 0;
+        }
         // if (cfg.write_crop_outputs && cfg.write_index) {
         //   roofer::draw_circle(
         //     ipc.nodata_circles[i],

--- a/src/core/reconstruction/ArrangementExtruder.cpp
+++ b/src/core/reconstruction/ArrangementExtruder.cpp
@@ -310,7 +310,7 @@ namespace roofer::reconstruction {
             // TODO: check if distance from px to p1 and p2 is longer than
             // snap_tolerance?
 
-            extra_wall_points[edge] = *px;
+            extra_wall_points.at(edge) = *px;
             // EPECK::Point_2 px_2d(px->x(),px->y());
             // arr.split_edge(edge, AT::Segment_2(p1,px_2d),
             // AT::Segment_2(px_2d,p2)); if (result) { auto px = )
@@ -351,7 +351,7 @@ namespace roofer::reconstruction {
             // TODO: check if distance from px to p1 and p2 is longer than
             // snap_tolerance?
 
-            extra_wall_points[edge] = *px;
+            extra_wall_points.at(edge) = *px;
             // EPECK::Point_2 px_2d(px->x(),px->y());
             // arr.split_edge(edge, AT::Segment_2(p1,px_2d),
             // AT::Segment_2(px_2d,p2)); if (result) { auto px = )

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -14,19 +14,19 @@ FetchContent_Declare(
   SOURCE_DIR "${DATA_DIR}/wippolder")
 FetchContent_MakeAvailable(wippolder)
 
-FetchContent_Declare(
-  wateringen
-  URL "${DATA_URL_ROOT}/wateringen.zip"
-  URL_HASH MD5=f96240033427f03cffeeb2d3cae63f3a
-  SOURCE_DIR "${DATA_DIR}/wateringen")
-FetchContent_MakeAvailable(wateringen)
-
-FetchContent_Declare(
-  wateringen_large
-  URL "${DATA_URL_ROOT}/wateringen-large.zip"
-  URL_HASH MD5=10844a5722d8ffeb554363e404a3c27b
-  SOURCE_DIR "${DATA_DIR}/wateringen-large")
-FetchContent_MakeAvailable(wateringen_large)
+#FetchContent_Declare(
+#  wateringen
+#  URL "${DATA_URL_ROOT}/wateringen.zip"
+#  URL_HASH MD5=f96240033427f03cffeeb2d3cae63f3a
+#  SOURCE_DIR "${DATA_DIR}/wateringen")
+#FetchContent_MakeAvailable(wateringen)
+#
+#FetchContent_Declare(
+#  wateringen_large
+#  URL "${DATA_URL_ROOT}/wateringen-large.zip"
+#  URL_HASH MD5=10844a5722d8ffeb554363e404a3c27b
+#  SOURCE_DIR "${DATA_DIR}/wateringen-large")
+#FetchContent_MakeAvailable(wateringen_large)
 
 # --- Library testing
 include(Catch)

--- a/tests/config/roofer-wateringen.toml
+++ b/tests/config/roofer-wateringen.toml
@@ -6,6 +6,7 @@ id_attribute = "identificatie"
 name = "ahn4"
 quality = 1
 path = "data/wateringen"
+force_low_lod = true
 
 [parameters]
 cellsize = 0.5

--- a/tools/plot_traces.py
+++ b/tools/plot_traces.py
@@ -44,6 +44,7 @@ if __name__ == "__main__":
     colormap = {
         "crop": "#2BC5F0",
         "reconstruct": "#F08B2B",
+        "sort": "#E8667D",
         "serialize": "#9CF02B",
         "heap": "#CD2BF0",
         "rss": "#4F8A9B"

--- a/tools/plot_traces.py
+++ b/tools/plot_traces.py
@@ -36,19 +36,32 @@ if __name__ == "__main__":
     end_time = trace_df["time"].max()
     trace_df.loc[:, "duration"] = trace_df["time"].apply(lambda t: (t - start_time).total_seconds())
 
-    fig, (ax_counts, ax_heap) = plt.subplots(2, 1, layout='constrained')
-    # The expected groups are "crop", "reconstruct", "serialize", "heap"
+    ax_counts = plt.subplot(211)
+    plt.tick_params("x", labelbottom=False)
+    plt.grid(visible=True, which="major", axis="x")
+    ax_memory = plt.subplot(212, sharex=ax_counts)
+    linewidth = 2
+    colormap = {
+        "crop": "#2BC5F0",
+        "reconstruct": "#F08B2B",
+        "serialize": "#9CF02B",
+        "heap": "#CD2BF0",
+        "rss": "#4F8A9B"
+    }
+    # The expected groups are "crop", "reconstruct", "serialize", "heap", "rss"
     for name, group_df in trace_df.groupby("name"):
         if name != "heap" and name != "rss":
-            ax_counts.plot(group_df["duration"], group_df["count"], label=name)
+            ax_counts.plot(group_df["duration"], group_df["count"], label=name, color=colormap[name], linewidth=linewidth)
         else:
-            ax_heap.plot(group_df["duration"], group_df["count"], label=name)
+            ax_memory.plot(group_df["duration"], group_df["count"], label=name, color=colormap[name], linewidth=linewidth)
 
     ax_counts.set_ylabel("Nr. objects produced")
     ax_counts.legend()
     ax_counts.set_title(f"Total duration {(end_time - start_time).total_seconds():.2f}s")
-    ax_heap.set_xlabel(f"Duration of the complete program [s]")
-    ax_heap.set_ylabel('Memory usage [b]')
-    ax_heap.legend()
+
+    ax_memory.set_xlabel(f"Duration of the complete program [s]")
+    ax_memory.set_ylabel('Memory usage [b]')
+    ax_memory.legend()
+    plt.grid(visible=True, which="major", axis="x")
     plt.savefig(f"roofer_trace_plot.png")
     plt.close()

--- a/tools/plot_traces.py
+++ b/tools/plot_traces.py
@@ -17,7 +17,6 @@ if __name__ == "__main__":
     with path_log.open() as fo:
         log_json = json.load(fo)
 
-
     # Parse the trace messages for easy plotting
     def parse_trace_message(log):
         for record in log:
@@ -40,7 +39,7 @@ if __name__ == "__main__":
     fig, (ax_counts, ax_heap) = plt.subplots(2, 1, layout='constrained')
     # The expected groups are "crop", "reconstruct", "serialize", "heap"
     for name, group_df in trace_df.groupby("name"):
-        if name != "heap":
+        if name != "heap" and name != "rss":
             ax_counts.plot(group_df["duration"], group_df["count"], label=name)
         else:
             ax_heap.plot(group_df["duration"], group_df["count"], label=name)
@@ -49,6 +48,7 @@ if __name__ == "__main__":
     ax_counts.legend()
     ax_counts.set_title(f"Total duration {(end_time - start_time).total_seconds():.2f}s")
     ax_heap.set_xlabel(f"Duration of the complete program [s]")
-    ax_heap.set_ylabel('Heap allocation [b]')
+    ax_heap.set_ylabel('Memory usage [b]')
+    ax_heap.legend()
     plt.savefig(f"roofer_trace_plot.png")
     plt.close()

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -36,8 +36,8 @@
       ]
     },
     {
-      "name": "libfork",
-      "version>=": "3.8.0"
+      "name": "bshoshany-thread-pool",
+      "version>=": "4.1.0"
     }
   ],
   "overrides": [


### PR DESCRIPTION
# Overview

Adds multithreaded execution and parallel reconstruction.
The roofer process is split into four stages. Each stage runs on its own thread, processing data as soon as it receives it. Thus, once the cropper is done with the first tile, the reconstruction of that tile begins immediately, followed by sorting and serialization.

- crop (serial)
- reconstruct (parallel)
- sort (serial)
- serialize (serial)

Thread synchronization is managed with mutexes and condition variables. 
Data is moved from one deque to another among the stages and finally deleted after it is serialized.

The chart shows the performance of a run of a large area around Den Haag (~150k buildings), split to 80 tiles. Using jemalloc as allocator, on gilfoyle. Memory usage seem to be stable, although the opening "scissor" of the heap and resident memory use needs to be investigated more thoroughly.
![image](https://github.com/user-attachments/assets/beb61b80-23de-44d7-bfae-89d221fd6b1d)

# Details

## Stages

Cropping is a serial process that produces one `BuildingTile` after another.

The reconstructor thread pushes the buildings of a tile onto the reconstruction queue, and each building is submitted as a task onto the reconstruction-thread-pool. The threads are detached, and they run as long as the cropper is running or there are cropped buildings. When a building is finished, the corresponding `Progress` enum is set to `RECONSTRUCTION_SUCCEEDED` or `RECONSTRUCTION_FAILED`.

The reconstructed buildings are finished in random order, so the sorter thread collects the finished (failed or succeeded) buildings of a tile, and place them back into the tile in their original order. A tile is finished when all of its buildings are either `RECONSTRUCTION_SUCCEEDED` or `RECONSTRUCTION_FAILED`.

The complete tiles are serialized by the serializer thread and finally released from memory.

## Objects

The new `Progress` enum signals the progress of a building along the roofer process. It is implemented as: 

```cpp
enum Progress : std::uint8_t {
  CROP_NOT_STARTED,
  CROP_IN_PROGRESS,
  CROP_SUCCEEDED,
  CROP_FAILED,
  RECONSTRUCTION_IN_PROGRESS,
  RECONSTRUCTION_SUCCEEDED,
  RECONSTRUCTION_FAILED,
  SERIALIZATION_IN_PROGRESS,
  SERIALIZATION_SUCCEEDED,
  SERIALIZATION_FAILED,
};
```
However, currently only RECONSTRUCTION_IN_PROGRESS, RECONSTRUCTION_SUCCEEDED, RECONSTRUCTION_FAILED are strictly necessary, and perhaps CROP_NOT_STARTED. I added the rest for the sake of completeness. I'm not sure whether I should keep them or remove them?

The `BuildingTile` now stores a vector of `Progress` to store progress of each building. This approach is similar to how the attributes are stored. Currently, the building progress is only used by the sorter to check for finished tiles, but later on we could use it for other purposes too.

I changed the `BuildingTile.buildings` from deque to vector, because I noticed slightly better performance, we did not strictly need a double-ended queue for this.  Although, the perf improvement might have been due to some other factor, did not really investigate it.

The `BuildingTile` now has a sequential ID.

The new `BuildingObjectRef` is used for keeping track of the tile ID, building's index in tile.buildings, and its progress, so that the building can be placed back into its original location in the tile by the sorter.

## Tracing

The new `--trace` option enables tracing, which emits counts at fixed intervals. 

With the `spdlog` backend, the logs are stored in a json file and trace messages are emmited as json objects. 